### PR TITLE
Add response handler for nodata case (CRM getRecords)

### DIFF
--- a/lib/crm.js
+++ b/lib/crm.js
@@ -143,6 +143,11 @@ CRM.prototype._request = function (method, endpoint, params, callback) {
             code: data.response.error.code,
             message: data.response.error.message
           }, null);
+        } else if (data.response.nodata) {
+          return callback({
+            code: data.response.nodata.code,
+            message: data.response.nodata.message
+          }, null);
         } else {
           var object = {};
 


### PR DESCRIPTION
This is the response for CRM getRecords API when no data met the criteria:
```
{
  "response": {
    "nodata": {
      "message": "There is no data to show",
      "code": "4422"
    },
    "uri": "/crm/private/json/CustomModule1/getRecords"
  }
}
```

Previously, it throws error in this line:
```
object.code = data.response.result.code || 0;
```
Because `data.response.result` is undefined.